### PR TITLE
Replace deprecated `gulp-util`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: node_js
 
 node_js:
-  - "0.10"
+  - "10"
+  - "8"
+  - "6"
 
 before_install:
   - npm install -g mocha

--- a/index.js
+++ b/index.js
@@ -6,8 +6,7 @@
 'use strict';
 
 var through = require('through');
-var gutil = require('gulp-util');
-var PluginError = gutil.PluginError;
+var PluginError = require('plugin-error');
 var path = require('path');
 var defaults = require('lodash.defaults');
 

--- a/package.json
+++ b/package.json
@@ -16,15 +16,16 @@
         "url": "https://github.com/hoho/gulp-dedupe/issues"
     },
     "dependencies": {
-        "gulp-util": "~3.0.1",
-        "through": "~2.3.6",
-        "lodash.defaults": "~2.4.1",
         "colors": "~1.0.2",
-        "diff": "~1.0.8"
+        "diff": "~1.0.8",
+        "lodash.defaults": "~2.4.1",
+        "plugin-error": "^1.0.1",
+        "through": "~2.3.6"
     },
     "devDependencies": {
         "mocha": "*",
-        "should": "*"
+        "should": "*",
+        "vinyl": "^2.1.0"
     },
     "scripts": {
         "test": "mocha"

--- a/test/main.js
+++ b/test/main.js
@@ -2,7 +2,7 @@ var dedupe = require('../');
 var should = require('should');
 var through = require('through');
 var path = require('path');
-var File = require('gulp-util').File;
+var Vinyl = require('vinyl');
 var Buffer = require('buffer').Buffer;
 var fs = require('fs');
 require('mocha');
@@ -110,7 +110,7 @@ describe('gulp-dedupe', function() {
                 });
 
                 while (files.length) {
-                    stream.write(new File({
+                    stream.write(new Vinyl({
                         path: files.shift(),
                         contents: new Buffer(files.shift())
                     }));


### PR DESCRIPTION
[`gulp-util`](https://www.npmjs.com/package/gulp-util) has been deprecated recently. Continuing to use this dependency may prevent the use of your library with the recently released version 4 of Gulp.

The [README.md](https://github.com/gulpjs/gulp-util) lists alternatives for all the components so a simple replacement should be enough.

Your package is popular but still relying on `gulp-util`, it would be good to publish a fixed version to npm as soon as possible.

See:
- https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5
- https://github.com/gulpjs/gulp-util/issues/143